### PR TITLE
Remove the submodule for i-d-template, so we use HEAD.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "lib"]
-	path = lib
-	url = https://github.com/martinthomson/i-d-template


### PR DESCRIPTION
This is an attempt to fix the TravisCI build.